### PR TITLE
Adds workflow to restrict PRs to dev -> main

### DIFF
--- a/.github/workflows/only_dev_to_main.yml
+++ b/.github/workflows/only_dev_to_main.yml
@@ -1,0 +1,29 @@
+name: Only allow PRs from Dev to Main
+description: This workflow ensures that only pull requests from the Dev branch to the Main branch are allowed.
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  pull-requests: write
+
+jobs:
+  check-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if PR is from Dev to Main
+        run: |
+          if [[ "${{ github.event.pull_request.base.ref }}" != "main" || "${{ github.event.pull_request.head.ref }}" != "dev" ]]; then
+            echo "This workflow only allows pull requests from Dev to Main."
+            curl -X POST -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+              -d '{"body": "Only Pull Requests from [dev](https://github.com/An0n-00/M426/tree/dev) are allowed to be merged to [main](https://github.com/An0n-00/M426/tree/main). I will close this PR. Please merge into dev before merging to main.❌"}' \
+              "https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments"
+            curl -X PATCH -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+              -d '{"state": "closed"}' \
+              "https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}"
+            exit 0
+          else
+            echo "Pull request is valid✅"
+          fi


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to enforce branch management policies by ensuring that only pull requests from the `dev` branch to the `main` branch are allowed. This helps maintain a clean and controlled release process.

Branch protection and workflow automation:

* Added `.github/workflows/only_dev_to_main.yml` workflow that automatically checks the source and target branches of pull requests, only allowing merges from `dev` to `main`. If the PR does not meet this requirement, the workflow posts a comment explaining the policy and closes the pull request.